### PR TITLE
Updated the module to work with PHP 7.1.

### DIFF
--- a/includes/asset.entityController.inc
+++ b/includes/asset.entityController.inc
@@ -32,7 +32,7 @@ class AssetController extends EntityAPIController {
       'changed'     => '',
       'instance_id' => NULL,
       'status'      => 1,
-      'data'        => '',
+      'data'        => array(),
     );
 
     $asset = parent::create($values);

--- a/includes/assetInstance.entityController.inc
+++ b/includes/assetInstance.entityController.inc
@@ -27,7 +27,7 @@ class AssetInstanceController extends EntityAPIController {
       'is_new'    => TRUE,
       'type'      => $values['asset']->type,
       'asset_id' => $values['asset']->id,
-      'data'      => '',
+      'data'      => array(),
     );
     // Clean up.
     unset($values['asset']);


### PR DESCRIPTION
As written, the module is not compatible with PHP 7.1.

It initializes `AssetController->data` as an empty string, then later does operations like it should be an Array.

I changed it so it starts as an empty Array.